### PR TITLE
Fix crash if called from deleted dir

### DIFF
--- a/src/common/fs_sys_helpers.cpp
+++ b/src/common/fs_sys_helpers.cpp
@@ -272,8 +272,12 @@ static bfs::path
 get_current_exe_path(std::string const &argv0) {
   // Linux
   auto exe = bfs::path{"/proc/self/exe"};
-  if (bfs::exists(exe))
-    return bfs::absolute(bfs::read_symlink(exe)).parent_path();
+  if (bfs::exists(exe)) {
+    auto exe_path = bfs::read_symlink(exe);
+
+    // only make absolute if needed, to avoid crash in case the current dir is deleted (as bfs::absolute calls bfs::current_path here)
+    return (exe_path.is_absolute() ? exe_path : bfs::absolute(exe_path)).parent_path();
+  }
 
   if (argv0.empty())
     return bfs::current_path();


### PR DESCRIPTION
[re-request after #1160]

You're right; it makes more sense to explain the details in the commit message to be independent from any platform. This is now done.
I agree with you that it is more safe to just add a check for already being absolute, to avoid any possible problem here. Your posted code sample works flawlessly so I adopted it and added an additional comment, so that anytime later the reason for this is understandable.