### PR TITLE
Set debhelper version to 9

### DIFF
--- a/debian-upstream/control
+++ b/debian-upstream/control
@@ -5,7 +5,7 @@ Maintainer: Moritz Bunkus <moritz@bunkus.org>
 Homepage: https://www.bunkus.org/videotools/mkvtoolnix/
 Standards-Version: 3.9.5
 Build-Depends:
- debhelper (>= 7.0.50~), libwxgtk3.0-dev | libwxgtk2.8-dev,
+ debhelper (>= 9), libwxgtk3.0-dev | libwxgtk2.8-dev,
  ruby (>= 1.9) | ruby1.9 | ruby1.9.1 | ruby1.9.3,
  libbz2-dev, liblzo2-dev, zlib1g-dev, libmagic-dev,
  libflac-dev, libogg-dev, libvorbis-dev,


### PR DESCRIPTION
Just a small packaging fix.
The debhelper version should match the compat level specified in debian/compat, or else a warning appears during source package creation: `mkvtoolnix source: package-needs-versioned-debhelper-build-depends 9`