### PR TITLE
Use -fPIE instead of -fPIC

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -111,7 +111,7 @@ def setup_globals
   cflags_common           += " -Ilib/libebml -Ilib/libmatroska"                          if c?(:EBML_MATROSKA_INTERNAL)
   cflags_common           += " #{c(:MATROSKA_CFLAGS)} #{c(:EBML_CFLAGS)} #{c(:EXTRA_CFLAGS)} #{c(:DEBUG_CFLAGS)} #{c(:PROFILING_CFLAGS)} #{c(:USER_CPPFLAGS)}"
   cflags_common           += " -mno-ms-bitfields -DWINVER=0x0500 -D_WIN32_WINNT=0x0500 " if c?(:MINGW)
-  cflags_common           += " -fPIC "                                                   if c?(:USE_QT) && !c?(:MINGW)
+  cflags_common           += " -fPIE "                                                   if c?(:USE_QT) && !c?(:MINGW)
   cflags_common           += " -DQT_STATICPLUGIN"                                        if c?(:USE_QT) && c?(:MINGW)
 
   cflags                   = "#{cflags_common} #{c(:USER_CFLAGS)}"


### PR DESCRIPTION
Since we're building executables, not shared libraries. Maybe you want to add `-pie` to LDFLAGs too.