### PR TITLE
add DTS:X bitstream detection

### DIFF
--- a/src/common/bit_cursor.h
+++ b/src/common/bit_cursor.h
@@ -159,6 +159,14 @@ public:
       skip_bits(m_bits_valid);
   }
 
+  bool bit_align(std::size_t align) {
+    auto pos = (get_bit_position() + align - 1) & ~(align - 1);
+    if (pos > (static_cast<std::size_t>(m_end_of_data - m_start_of_data) * 8))
+      return false;
+    set_bit_position(pos);
+    return true;
+  }
+
   void set_bit_position(std::size_t pos) {
     if (pos > (static_cast<std::size_t>(m_end_of_data - m_start_of_data) * 8)) {
       m_byte_position = m_end_of_data;

--- a/src/common/dts.h
+++ b/src/common/dts.h
@@ -28,6 +28,7 @@ enum class sync_word_e {
   , lbr  = 0x0a801921
   , xll  = 0x41a29547
   , x96  = 0x1d95f262
+  , x    = 0x02000850 // DTS:X
 };
 
 enum class frametype_e {
@@ -82,6 +83,7 @@ enum class dts_type_e {
   , express
   , es
   , x96_24
+  , x
 };
 
 enum class source_pcm_resolution_e {
@@ -242,7 +244,6 @@ public:
 protected:
   bool decode_asset(bit_reader_c &bc, substream_asset_t &asset);
   bool decode_lbr_header(bit_reader_c &bc, substream_asset_t &asset);
-  bool decode_xll_header(bit_reader_c &bc, substream_asset_t &asset);
   void parse_lbr_parameters(bit_reader_c &bc, substream_asset_t &asset);
   void parse_xll_parameters(bit_reader_c &bc, substream_asset_t &asset);
 

--- a/src/common/dts_xll.cpp
+++ b/src/common/dts_xll.cpp
@@ -1,0 +1,481 @@
+/*
+   mkvtoolnix - programs for manipulating Matroska files
+   Copyright © 2003…2016 Moritz Bunkus
+
+   This file is distributed as part of mkvtoolnix and is distributed under the
+   GNU General Public License Version 2, or (at your option) any later version.
+   See accompanying file COPYING for details or visit
+   http://www.gnu.org/licenses/gpl.html .
+
+   DTS XLL decode support
+
+   Authors: KonaBlend <kona8lend@gmail.com>
+*/
+
+#include "common/common_pch.h"
+#include "common/bswap.h"
+#include "common/checksums/crc.h"
+#include "common/dts.h"
+#include "common/dts_xll.h"
+#include "common/format.h"
+#include "common/sbrm.h"
+
+#define dformat(...) mxdebug(format::format(__VA_ARGS__))
+#define dfield(...)  mxdebug(table.field(__VA_ARGS__))
+
+namespace mtx { namespace dts { namespace {
+
+xll_header_common_cptr      decode_xll_header_common(bit_reader_c &,
+                                                     header_t::substream_asset_t const &);
+xll_header_channel_set_cptr decode_xll_header_channel_set(bit_reader_c &,
+                                                     header_t::substream_asset_t const &,
+                                                     xll_header_t const &);
+xll_header_navi_cptr        decode_xll_header_navi(bit_reader_c &,
+                                                   xll_header_t const &);
+xll_header_x_cptr           decode_xll_header_x(bit_reader_c &);
+
+static debugging_option_c s_debug{"dts_xll"};
+
+/******************************************************************************
+ *
+ * Calculate 16-bit CRC-CCITT checksum with bit_reader.
+ *
+ * If restore_bit_position is true, position will be restored. Otherwise,
+ * position will be immediately after checksum data.
+ */
+uint16_t
+bc_crc16(bit_reader_c &bc,
+         int data_offset,
+         int data_size,
+         uint16_t &crc16,
+         bool restore_bit_position) {
+  auto const saved_bit_pos = bc.get_bit_position();
+  auto buf = memory_c::alloc(data_size);
+  bc.set_bit_position(data_offset*8);
+  bc.get_bytes(buf->get_buffer(), buf->get_size());
+  crc16 = bc.get_bits(16);
+  auto ret_crc16 = mtx::bswap_16(mtx::checksum::calculate_as_uint(mtx::checksum::algorithm_e::crc16_ccitt,
+                                                                  buf->get_buffer(),
+                                                                  buf->get_size(),
+                                                                  0xffff));
+  if (restore_bit_position)
+    bc.set_bit_position(saved_bit_pos);
+  return ret_crc16;
+}
+
+} // namespace (anonymous)
+
+/*****************************************************************************/
+
+xll_header_channel_set_t::downmix_table_t xll_header_channel_set_t::s_downmix_table[8] = {
+  { 1, YT("1/0") },
+  { 2, YT("Lo/Ro") },
+  { 2, YT("Lt/Rt") },
+  { 3, YT("3/0") },
+  { 3, YT("2/1") },
+  { 4, YT("2/2") },
+  { 4, YT("3/1") },
+  { 0, YT("unused") },
+};
+
+/*****************************************************************************/
+
+xll_header_cptr
+decode_xll_header(bit_reader_c &bc, header_t::substream_asset_t const &asset) {
+  bc.set_bit_position((asset.xll_offset + asset.xll_sync_offset) * 8);
+  sbrm::result_guard_c<xll_header_t> h([&, pos=bc.get_bit_position()](bool){
+    if (h.success)
+      return;
+    bc.set_bit_position(pos);
+    h.result = nullptr;
+  });
+  h.make_result();
+
+  // when sync not present simply return success with empty result
+  if (!asset.xll_sync_present)
+    return h(true);
+
+  h->common = decode_xll_header_common(bc, asset);
+  if (!h->common)
+    return h();
+
+  for (int i = 0; i < h->common->num_channel_sets; ++i) {
+    auto cs = decode_xll_header_channel_set(bc, asset, **h);
+    if (!cs)
+      return h();
+    h->channel_sets.push_back(cs);
+  }
+
+  h->navi = decode_xll_header_navi(bc, **h);
+  if (!h->navi)
+    return h();
+
+  // skip band data
+  bc.skip_bits(h->navi->total_band_data_size*8);
+
+  // presence is optional
+  h->dtsx = decode_xll_header_x(bc);
+
+  if (s_debug)
+    h->dump(asset);
+
+  return h(true);
+}
+
+/*****************************************************************************/
+
+namespace {
+
+xll_header_common_cptr
+decode_xll_header_common(bit_reader_c &bc, header_t::substream_asset_t const &asset) {
+  auto const begin_bit_pos = bc.get_bit_position();
+  sbrm::result_guard_c<xll_header_common_t> h([&](bool){
+    if (h.success)
+      return;
+    bc.set_bit_position(begin_bit_pos);
+    h.result = nullptr;
+  });
+  h.make_result();
+
+  h->sync_word = bc.get_bits(32);
+  if (h->sync_word != static_cast<uint32_t>(sync_word_e::xll))
+    return h();
+
+  h->version = bc.get_bits(4) + 1;
+  h->header_size = bc.get_bits(8) + 1;
+
+  auto crc16_tmp = bc_crc16(bc, (begin_bit_pos + 32)/8, h->header_size - 6, h->crc16, true);
+  h->crc16_valid = crc16_tmp == h->crc16;
+  if (!h->crc16_valid)
+    return h();
+
+  h->frame_size_bits = bc.get_bits(5) + 1;
+  h->frame_size = bc.get_bits(h->frame_size_bits) + 1;
+  h->num_channel_sets = bc.get_bits(4) + 1;
+  h->num_segments = 1 << bc.get_bits(4);
+  h->samples_per_segment = 1 << bc.get_bits(4);
+  h->navi_data_size_bits = bc.get_bits(5) + 1;
+  h->band_data_crc = bc.get_bits(2);
+  h->scalable_lsb = bc.get_bits(1);
+  h->channel_mask_bits = bc.get_bits(5) + 1;
+  if (h->scalable_lsb)
+    h->num_fixed_lsb_width = bc.get_bits(4);
+
+  bc.set_bit_position(begin_bit_pos + h->header_size*8); // end of common header
+  return h(true);
+}
+
+/*****************************************************************************/
+
+xll_header_channel_set_cptr
+decode_xll_header_channel_set(bit_reader_c &bc,
+                              header_t::substream_asset_t const &asset,
+                              xll_header_t const &xll) {
+  auto const begin_bit_pos = bc.get_bit_position();
+  sbrm::result_guard_c<xll_header_channel_set_t> h([&](bool){
+    if (h.success)
+      return;
+    bc.set_bit_position(begin_bit_pos);
+    h.result = nullptr;
+  });
+  h.make_result();
+
+  h->header_size = bc.get_bits(10) + 1;
+
+  auto crc16_tmp = bc_crc16(bc, begin_bit_pos/8, h->header_size - 2, h->crc16, true);
+  h->crc16_valid = crc16_tmp == h->crc16;
+  if (!h->crc16_valid)
+    return h();
+
+  h->num_channels = bc.get_bits(4) + 1;
+  h->residual_channel_encode = bc.get_bits(h->num_channels);
+  h->bit_resolution = bc.get_bits(5) + 1;
+  h->bit_width = bc.get_bits(5) + 1;
+  h->frequency_index = bc.get_bits(4);
+
+  static uint32_t const s_frequency_table[16] = {
+    8000, 16000, 32000, 64000, 128000,
+    22050, 44100, 88200, 176400, 352800,
+    12000, 24000, 48000, 96000, 192000, 384000,
+  };
+  h->frequency = s_frequency_table[h->frequency_index];
+
+  h->ifactor_index = bc.get_bits(2);
+
+  static uint8_t const s_ifactor_table[4] = { 1, 2, 4, 8 };
+  h->interpolation_factor = s_ifactor_table[h->ifactor_index];
+
+  h->replacement_set = bc.get_bits(2);
+
+  if (h->replacement_set != 0)
+    h->active_replace_set = bc.get_bits(1) == 1;
+
+  if (asset.one_to_one_map_channel_to_speaker) {
+    h->primary_channel_set = bc.get_bits(1) == 1;
+
+    h->downmix_coeffs_present = bc.get_bits(1) == 1;
+    if (h->downmix_coeffs_present) {
+      h->downmix_embedded = bc.get_bits(1) == 1;
+      if (h->primary_channel_set)
+        h->downmix_type = bc.get_bits(3);
+    }
+
+    h->hierarchical_channel_set = bc.get_bits(1) == 1;
+
+    if (h->downmix_coeffs_present) {
+      int n;
+      int m;
+      if (h->primary_channel_set) {
+        n = h->num_channels;
+        m = xll_header_channel_set_t::s_downmix_table[h->downmix_type].nchan;
+      } else {
+        n = h->num_channels + 1;
+        m = 0;
+        for (auto cs : xll.channel_sets) {
+          if (cs->hierarchical_channel_set)
+            m += cs->num_channels;
+        }
+      }
+      bc.skip_bits(n*m*9);
+    }
+
+    h->channel_mask_enabled = bc.get_bits(1) == 1;
+    if (h->channel_mask_enabled) {
+      h->channel_mask = bc.get_bits(xll.common->channel_mask_bits);
+    } else {
+      for (int i = 0; i < h->num_channels; ++i) {
+        bc.skip_bits(9);
+        bc.skip_bits(9);
+        bc.skip_bits(7);
+      }
+    }
+  } else {
+    h->primary_channel_set = true;
+    h->downmix_coeffs_present = false;
+    h->hierarchical_channel_set = true;
+
+    h->mapping_coefficient_present = bc.get_bits(1) == 1;
+    if (h->mapping_coefficient_present) {
+      h->chan_to_speaker_mapping_coeff_bits = 6 + 2 * bc.get_bits(3);
+
+      uint8_t const num_loudspeaker_configs = bc.get_bits(2) + 1;
+      h->loudspeaker_configs.resize(num_loudspeaker_configs);
+      for (auto &lc : h->loudspeaker_configs) {
+        lc.active_channel_mask = bc.get_bits(h->num_channels);
+        lc.num_speakers = bc.get_bits(6) + 1;
+        lc.speaker_mask_enabled = bc.get_bits(1) == 1;
+        if (lc.speaker_mask_enabled)
+          lc.speaker_mask = bc.get_bits(xll.common->channel_mask_bits);
+
+        for (auto speaker_idx = 0; speaker_idx < num_loudspeaker_configs; ++speaker_idx) {
+          if (!lc.speaker_mask_enabled)
+            bc.skip_bits(25);
+          for (auto channel_idx = 0; channel_idx < h->num_channels; ++channel_idx) {
+            if (lc.active_channel_mask & (1 << channel_idx))
+              bc.skip_bits(h->chan_to_speaker_mapping_coeff_bits);
+          }
+        }
+      }
+    }
+  }
+
+  if (h->frequency > 96000) {
+    h->extra_frequency_bands = bc.get_bits(1) == 1;
+
+    if (h->extra_frequency_bands)
+      h->num_frequency_bands = 4;
+    else
+      h->num_frequency_bands = 2;
+  } else {
+    h->num_frequency_bands = 1;
+  }
+
+  bc.set_bit_position(begin_bit_pos + h->header_size*8); // end of channel-set header
+  return h(true);
+}
+
+/*****************************************************************************/
+
+xll_header_navi_cptr
+decode_xll_header_navi(bit_reader_c &bc,
+                       xll_header_t const &xll) {
+  auto const begin_bit_pos = bc.get_bit_position();
+  sbrm::result_guard_c<xll_header_navi_t> h([&](bool){
+    if (h.success)
+      return;
+    bc.set_bit_position(begin_bit_pos);
+    h.result = nullptr;
+  });
+  h.make_result();
+
+  int num_bands = 0;
+  for (auto cs : xll.channel_sets) {
+    if (cs->num_frequency_bands > num_bands)
+      num_bands = cs->num_frequency_bands;
+  }
+
+  h->total_band_data_size = 0;
+  for (int band = 0; band < num_bands; ++band) {
+    for (int seg = 0; seg < xll.common->num_segments; ++seg) {
+      int csi = 0;
+      for (auto cs : xll.channel_sets) {
+        if (cs->num_frequency_bands <= band)
+          continue;
+        auto frame_size = bc.get_bits(xll.common->navi_data_size_bits) + 1;
+        h->total_band_data_size += frame_size;
+        csi++;
+      }
+    }
+  }
+
+  bc.byte_align();
+  auto crc16_tmp = bc_crc16(bc, begin_bit_pos/8, (bc.get_bit_position() - begin_bit_pos)/8, h->crc16, false);
+  h->crc16_valid = crc16_tmp == h->crc16;
+  if (!h->crc16_valid)
+    return h();
+
+  return h(true);
+}
+
+/*****************************************************************************/
+
+xll_header_x_cptr
+decode_xll_header_x(bit_reader_c &bc) {
+  sbrm::result_guard_c<xll_header_x_t> h([&, pos=bc.get_bit_position()](bool){
+    if (h.success)
+      return;
+    bc.set_bit_position(pos);
+    h.result = nullptr;
+  });
+  h.make_result();
+
+  // align at 4-byte
+  if (!bc.bit_align(32))
+    return h();
+
+  if (bc.get_remaining_bits() < 32)
+    return h();
+
+  h->sync_word = bc.get_bits(32);
+  if (h->sync_word != static_cast<uint32_t>(sync_word_e::x))
+    return h();
+
+  return h(true);
+}
+
+} // namespace (anonymous)
+
+/*****************************************************************************/
+
+void
+xll_header_t::dump(header_t::substream_asset_t const &asset) const {
+  dformat("DTS XLL HEADER\n");
+  dformat("  COMMON\n");
+  common->dump();
+
+  uint8_t csi{};
+  for (auto &cs : channel_sets) {
+    dformat("  CHANNEL SET[%1%]\n", csi);
+    cs->dump(asset);
+    ++csi;
+  }
+
+  dformat("  NAVI\n");
+  navi->dump();
+
+  if (dtsx) {
+    dformat("  DTS:X\n");
+    dtsx->dump();
+  }
+}
+
+void
+xll_header_common_t::dump() const {
+  format::table_t table{4, 19};
+  dfield("sync_word", "%1$#010x", sync_word);
+  dfield("version", "%1%", version);
+  dfield("header_size", "%1%", header_size);
+  dfield("frame_size_bits", "%1%", frame_size_bits);
+  dfield("frame_size", "%1%", frame_size);
+  dfield("num_channel_sets", "%1%", num_channel_sets);
+  dfield("num_segments", "%1%", num_segments);
+  dfield("samples_per_segment", "%1%", samples_per_segment);
+  dfield("navi_data_size_bits", "%1%", navi_data_size_bits);
+  dfield("band_data_crc", "%1%", band_data_crc);
+  dfield("scalable_lsb", "%1%", scalable_lsb);
+  dfield("channel_mask_bits", "%1%", channel_mask_bits);
+  if (scalable_lsb)
+    dfield("num_fixed_lsb_width", "%1%", num_fixed_lsb_width);
+  dfield("crc16", "%1$#06x (%2%)", crc16, (crc16_valid ? "valid" : "invalid"));
+}
+
+void
+xll_header_channel_set_t::dump(header_t::substream_asset_t const &asset) const {
+  format::table_t table{4, 35};
+  dfield("header_size", "%1%", header_size);
+  dfield("num_channels", "%1%", num_channels);
+  dfield("residual_channel_encode", "%1$#06x", residual_channel_encode);
+  dfield("bit_resolution", "%1%", bit_resolution);
+  dfield("bit_width", "%1%", bit_width);
+  dfield("frequency_index", "%1%", frequency_index);
+  dfield("frequency", "%1%", frequency);
+  dfield("ifactor_index", "%1%", ifactor_index);
+  dfield("interpolation_factor", "%1%", interpolation_factor);
+  dfield("replacement_set", "%1%", replacement_set);
+  if (replacement_set != 0)
+    dfield("active_replace_set", "%1%", active_replace_set);
+
+  dfield("(one_to_one_map_channel_to_speaker)", "%1%", asset.one_to_one_map_channel_to_speaker);
+  if (asset.one_to_one_map_channel_to_speaker) {
+    dfield("primary_channel_set", "%1%", primary_channel_set);
+    dfield("downmix_coeffs_present", "%1%", downmix_coeffs_present);
+    if (downmix_coeffs_present) {
+      dfield("downmix_embedded", "%1%", downmix_embedded);
+      if (primary_channel_set)
+        dfield("downmix_type", "%1% (%2%)", downmix_type, s_downmix_table[downmix_type].descr);
+    }
+    dfield("hierarchical_channel_set", "%1%", hierarchical_channel_set);
+    dfield("channel_mask_enabled", "%1%", channel_mask_enabled);
+    if (channel_mask_enabled)
+      dfield("channel_mask", "%1$#06x", channel_mask);
+  } else {
+    dfield("primary_channel_set", "%1%", primary_channel_set);
+    dfield("downmix_coeffs_present", "%1%", downmix_coeffs_present);
+    dfield("hierarchical_channel_set", "%1%", hierarchical_channel_set);
+    dfield("mapping_coefficient_present", "%1%", mapping_coefficient_present);
+    if (mapping_coefficient_present) {
+      dfield("chan_to_speaker_mapping_coeff_bits", "%1$#04x", chan_to_speaker_mapping_coeff_bits);
+      dfield("num_loudspeaker_configs", "%1%", loudspeaker_configs.size());
+      uint8_t lci{};
+      table.indent += 2;
+      for (auto &lc : loudspeaker_configs) {
+        dformat(    "loudspeaker_config[%1%]\n", lci);
+        dfield("active_channel_mask", "%1$#06x", lc.active_channel_mask);
+        dfield("num_speakers", "%1%", lc.num_speakers);
+        dfield("speaker_mask_enabled", "%1%", lc.speaker_mask_enabled);
+        if (lc.speaker_mask_enabled)
+          dfield("speaker_mask", "%1$#08x", lc.speaker_mask);
+      }
+      table.indent -= 2;
+    }
+  }
+
+  dfield("extra_frequency_bands", "%1%", extra_frequency_bands);
+  dfield("num_frequency_bands", "%1%", num_frequency_bands);
+  dfield("crc16", "%1$#06x (%2%)", crc16, (crc16_valid ? "valid" : "invalid"));
+}
+
+void
+xll_header_navi_t::dump() const {
+  format::table_t table{4, 21};
+  dfield("total_band_data_size", "%1%", total_band_data_size);
+  dfield("crc16", "%1$#04x (%2%)", crc16, (crc16_valid ? "valid" : "invalid"));
+}
+
+void
+xll_header_x_t::dump() const {
+  format::table_t table{4, 0};
+  dfield("sync_word", "%1$#010x", sync_word);
+}
+
+}} // namespace mtx::dts

--- a/src/common/dts_xll.h
+++ b/src/common/dts_xll.h
@@ -1,0 +1,178 @@
+/*
+   mkvtoolnix - programs for manipulating Matroska files
+   Copyright © 2003…2016 Moritz Bunkus
+
+   This file is distributed as part of mkvtoolnix and is distributed under the
+   GNU General Public License Version 2, or (at your option) any later version.
+   See accompanying file COPYING for details or visit
+   http://www.gnu.org/licenses/gpl.html .
+
+   DTS XLL decode support
+
+   Authors: KonaBlend <kona8lend@gmail.com>
+*/
+
+#ifndef MTX_COMMON_DTS_XLL_H
+#define MTX_COMMON_DTS_XLL_H
+
+#include "common/common_pch.h"
+#include "common/bit_cursor.h"
+#include "common/translation.h"
+
+namespace mtx { namespace dts {
+
+struct xll_header_t;
+struct xll_header_common_t;
+struct xll_header_channel_set_t;
+struct xll_header_navi_t;
+struct xll_header_x_t;
+
+using xll_header_cptr             = std::shared_ptr<xll_header_t>;
+using xll_header_common_cptr      = std::shared_ptr<xll_header_common_t>;
+using xll_header_channel_set_cptr = std::shared_ptr<xll_header_channel_set_t>;
+using xll_header_navi_cptr        = std::shared_ptr<xll_header_navi_t>;
+using xll_header_x_cptr           = std::shared_ptr<xll_header_x_t>;
+
+/******************************************************************************
+ *
+ * Decode XLL header.
+ *
+ * Decode XLL header returns a stored xll_header_t on success and nullptr on
+ * failure.
+ *
+ * xll_header->dtsx is true or false depending if DTS:X was detected
+ */
+xll_header_cptr decode_xll_header(bit_reader_c &, header_t::substream_asset_t const &);
+
+struct xll_header_t {
+  xll_header_t(const xll_header_t &) = delete;
+  xll_header_t(xll_header_t &&) = delete;
+  xll_header_t &operator=(const xll_header_t &) = delete;
+  xll_header_t &operator=(xll_header_t &&) = delete;
+
+  using channel_sets_t = std::vector<xll_header_channel_set_cptr>;
+
+  xll_header_t() = default;
+
+  void dump(header_t::substream_asset_t const &) const;
+
+  xll_header_common_cptr common{};
+  channel_sets_t         channel_sets{};
+  xll_header_navi_cptr   navi{};
+  xll_header_x_cptr      dtsx{};
+};
+
+struct xll_header_common_t {
+  xll_header_common_t(const xll_header_common_t &) = delete;
+  xll_header_common_t(xll_header_common_t &&) = delete;
+  xll_header_common_t &operator=(const xll_header_common_t &) = delete;
+  xll_header_common_t &operator=(xll_header_common_t &&) = delete;
+
+  xll_header_common_t() = default;
+
+  void dump() const;
+
+  uint32_t sync_word{};             // SYNCXLL
+  uint8_t  version{};               // nVersion
+  uint16_t header_size{};           // nHeaderSize
+  uint8_t  frame_size_bits{};       // nBits4FrameFsize
+  uint32_t frame_size{};            // nLLFrameSize
+  uint8_t  num_channel_sets{};      // numChSetsInFrame
+  uint8_t  num_segments{};          // nSegmentsInFrame
+  uint32_t samples_per_segment{};   // nSmplInSeg
+  uint8_t  navi_data_size_bits{};   // nBits4SSize
+  uint8_t  band_data_crc{};         // nBandDataCRCEn
+  bool     scalable_lsb{};          // bScalableLSBs
+  uint8_t  channel_mask_bits{};     // nBits4ChMask
+  uint8_t  num_fixed_lsb_width{};   // nuFixedLSBWidth
+  uint16_t crc16{};                 // nCRC16Header
+  bool     crc16_valid{};
+};
+
+struct xll_header_channel_set_t {
+  xll_header_channel_set_t(const xll_header_channel_set_t &) = delete;
+  xll_header_channel_set_t(xll_header_channel_set_t &&) = delete;
+  xll_header_channel_set_t &operator=(const xll_header_channel_set_t &) = delete;
+  xll_header_channel_set_t &operator=(xll_header_channel_set_t &&) = delete;
+
+  xll_header_channel_set_t() = default;
+
+  void dump(header_t::substream_asset_t const &) const;
+
+  uint16_t  header_size{};                          // m_nChSetHeaderSize
+  uint8_t   num_channels{};                         // m_nChSetLLChannel
+  uint16_t  residual_channel_encode{};              // m_nResidualChEncode
+  uint8_t   bit_resolution{};                       // m_nBitResolution
+  uint8_t   bit_width{};                            // m_nBitWidth
+  uint8_t   frequency_index{};                      // sFreqIndex
+  uint32_t  frequency{};                            // m_nFs
+  uint8_t   ifactor_index{};                        // nFsInterpolate
+  uint8_t   interpolation_factor{};
+  uint8_t   replacement_set{};                      // NReplacementSet
+  bool      active_replace_set{};                   // bActiveReplaceSet
+
+  bool      primary_channel_set{};                  // bPrimaryChSet
+  bool      downmix_coeffs_present{};               // bDownmixCoeffCodeEmbedded
+  bool      downmix_embedded{};                     // bDownmixEmbedded
+  uint8_t   downmix_type{};                         // nLLDownmixType
+  bool      hierarchical_channel_set{};             // BHierChSet
+  bool      channel_mask_enabled{};                 // bChMaskEnabled
+  uint32_t  channel_mask{};                         // nChMask
+
+  bool      mapping_coefficient_present{};          // bMappingCoeffsPresent
+  uint8_t   chan_to_speaker_mapping_coeff_bits{};   // nBitsCh2SpkrCoef
+
+  struct loudspeaker_config_t {
+    uint32_t active_channel_mask{};     // pnActiveChannelMask
+    uint8_t  num_speakers{};            // pnNumSpeakers
+    bool     speaker_mask_enabled{};    // bSpkrMaskEnabled
+    uint32_t speaker_mask{};            // nSpkrMask
+  };
+  using loudspeaker_configs_t = std::vector<loudspeaker_config_t>;
+
+  loudspeaker_configs_t loudspeaker_configs;        // nNumSpeakerConfigs
+
+  bool      extra_frequency_bands{};                // bXtraFreqBands
+  uint8_t   num_frequency_bands{};                  // m_nNumFreqBands
+  uint16_t  crc16{};                                // nCRC16SubHeader
+  bool      crc16_valid{};
+
+  struct downmix_table_t {
+    uint8_t nchan;                  // c++14 TODO: add default member initializer
+    translatable_string_c descr;    // c++14 TODO: add default member initializer
+  };
+
+  static downmix_table_t s_downmix_table[8];
+};
+
+struct xll_header_navi_t {
+  xll_header_navi_t(const xll_header_navi_t &) = delete;
+  xll_header_navi_t(xll_header_navi_t &&) = delete;
+  xll_header_navi_t &operator=(const xll_header_navi_t &) = delete;
+  xll_header_navi_t &operator=(xll_header_navi_t &&) = delete;
+
+  xll_header_navi_t() = default;
+
+  void dump() const;
+
+  uint64_t total_band_data_size{};
+  uint16_t crc16{};
+  bool     crc16_valid{};
+};
+
+struct xll_header_x_t {
+  xll_header_x_t(const xll_header_x_t &) = delete;
+  xll_header_x_t(xll_header_x_t &&) = delete;
+  xll_header_x_t &operator=(const xll_header_x_t &) = delete;
+  xll_header_x_t &operator=(xll_header_x_t &&) = delete;
+
+  xll_header_x_t() = default;
+
+  void dump() const;
+
+  uint32_t sync_word{};
+};
+
+}} // namespace mtx::dts
+
+#endif // MTX_COMMON_DTS_XLL_H

--- a/src/common/format.cpp
+++ b/src/common/format.cpp
@@ -1,0 +1,23 @@
+/*
+   mkvtoolnix - programs for manipulating Matroska files
+   Copyright © 2003…2016 Moritz Bunkus
+
+   This file is distributed as part of mkvtoolnix and is distributed under the
+   GNU General Public License Version 2, or (at your option) any later version.
+   See accompanying file COPYING for details or visit
+   http://www.gnu.org/licenses/gpl.html .
+
+   boost::format utilities.
+
+   Authors: KonaBlend <kona8lend@gmail.com>
+*/
+
+#include "common/common_pch.h"
+
+namespace mtx { namespace format {
+
+void
+format_each(boost::format &) {
+}
+
+}} // namespace mtx::format

--- a/src/common/format.h
+++ b/src/common/format.h
@@ -1,0 +1,101 @@
+/*
+   mkvtoolnix - programs for manipulating Matroska files
+   Copyright © 2003…2016 Moritz Bunkus
+
+   This file is distributed as part of mkvtoolnix and is distributed under the
+   GNU General Public License Version 2, or (at your option) any later version.
+   See accompanying file COPYING for details or visit
+   http://www.gnu.org/licenses/gpl.html .
+
+   boost::format utilities.
+
+   Authors: KonaBlend <kona8lend@gmail.com>
+*/
+
+#ifndef MTX_FORMAT_H
+#define MTX_FORMAT_H
+
+namespace mtx { namespace format {
+
+/******************************************************************************
+ *
+ * Debug/boost::format helper routines.
+ *
+ * - more terse
+ * - move from operator% to , separated args
+ * - use int8_t/uint8_t as integers
+ *
+ * Consider simplifying with fold-expressions when C++17 is engaged.
+ */
+
+void format_each(boost::format &);
+
+template<typename T>
+struct as_raw {
+  T value{};
+};
+
+template<typename Arg0, typename... Args>
+void
+format_each(boost::format &bf, Arg0 const &arg0, Args... args) {
+  bf % arg0;
+  format_each(bf, args...);
+}
+
+template<typename ART, typename... Args>
+void
+format_each(boost::format &bf, as_raw<ART> const &arg0, Args... args) {
+  bf % arg0.value;
+  format_each(bf, args...);
+}
+
+template<typename... Args>
+void
+format_each(boost::format &bf, bool const &arg0, Args... args) {
+  bf % (arg0 ? "true" : "false");
+  format_each(bf, args...);
+}
+
+template<typename... Args>
+void
+format_each(boost::format &bf, int8_t const &arg0, Args... args) {
+  bf % static_cast<unsigned>(arg0);
+  format_each(bf, args...);
+}
+
+template<typename... Args>
+void
+format_each(boost::format &bf, uint8_t const &arg0, Args... args) {
+  bf % static_cast<signed>(arg0);
+  format_each(bf, args...);
+}
+
+template<typename... Args>
+boost::format
+format(const char *spec, Args... args) try {
+  boost::format bf(spec);
+  format_each(bf, args...);
+  return bf;
+} catch (boost::io::format_error &e) {
+  return boost::format("%1%\n") % e.what();
+}
+
+struct table_t {
+  uint8_t indent;           // c++14 TODO: add default member initializer
+  uint8_t field_width;      // c++14 TODO: add default member initializer
+
+  template<typename... Args>
+  boost::format
+  field(std::string name, const char *spec, Args... args) try {
+    boost::format bf(spec);
+    format_each(bf, args...);
+    auto pad = name.length() > field_width ? 0 : field_width - name.length();
+    return boost::format("%1%%2%:%3%  %4%\n") % std::string(indent,' ') % name % std::string(pad,' ') % bf.str();
+  } catch (boost::io::format_error &e) {
+    return boost::format("%1%\n") % e.what();
+  }
+};
+
+}} // namespace mtx::format
+
+#endif // MTX_FORMAT_H

--- a/src/common/sbrm.h
+++ b/src/common/sbrm.h
@@ -1,0 +1,175 @@
+/*
+   mkvtoolnix - programs for manipulating Matroska files
+   Copyright © 2003…2016 Moritz Bunkus
+
+   This file is distributed as part of mkvtoolnix and is distributed under the
+   GNU General Public License Version 2, or (at your option) any later version.
+   See accompanying file COPYING for details or visit
+   http://www.gnu.org/licenses/gpl.html .
+
+   Scope-Bound Resource Management (SBRM) utilities.
+
+   Authors: KonaBlend <kona8lend@gmail.com>
+*/
+
+#ifndef MTX_SBRM_H
+#define MTX_SBRM_H
+
+namespace mtx { namespace sbrm {
+
+/******************************************************************************
+ *
+ * result_guard_c is a scope-bound resource manager geared for early-exit
+ * programming style. shared_ptr<T> becomes the result_t .
+ *
+ ******************************************************************************
+ *
+ * Idiomatic usage:
+ *
+ *      |  {
+ *    a |     result_guard_c<Foo> h([&](bool) {
+ *    b |       if (!h.success)
+ *    c |         h.result = nullptr;
+ *      |     });
+ *    d |     h.make_result();
+ *      |
+ *    e |     h->one = "hello";
+ *    i |     ...
+ *      |
+ *      |
+ *      |    if (!other_good_condition)
+ *    f |      return h();
+ *      |
+ *      |    h->two = "world";
+ *      |    ...
+ *      |
+ *    g |    return h(true);
+ *      | }
+ *
+ * a) create a guard on the stack for a new heap object
+ *    - h.result is a shared_ptr<Foo> default initialized (empty)
+ *    - h.success is a bool default initialized (false)
+ *    - h.callback is a void(bool) initialized to lambda body LINES(a..c)
+ *
+ *    * note: we avoid using keyword auto and assignment initialization
+ *      because that removes the ability to reference new variable in
+ *      lambda body; i.e. use of auto would emphasize the variable name but
+ *      fail compiling:
+ *
+ *      |  auto h = result_guard_c<Foo>([&](bool) {    // BAD
+ *      |    if (!h.success)                           // h not available
+ *      |      h.result = nullptr;
+ *      |  });
+ *
+ * b) callback checks if h was never marked as successful
+ *
+ * c) callback empties result, because in this idiom the goal is to return
+ *    empty on failure; i.e. do not let a partially populated Foo escape.
+ *
+ * d) set result to a new heap default-constructed Foo; equivalent to:
+ *
+ *      |  h.result = std::make_shared<Foo>();
+ *
+ * e) use class-member-access-operator to populate result; equivalent to:
+ *
+ *      |  h.result->one = "hello";
+ *
+ * f) fail by invoking function-call-operator for return.
+ *
+ * g) use function-call-operator to mark as successful and return;
+ *    equivalent to:
+ *
+ *      |  h.success = true;
+ *      |  return h.result;
+ *
+ ******************************************************************************
+ *
+ * The key public data members are exposed for maximum flexibility falling
+ * outside idiomatic usage:
+ *
+ *     success: indicates if function was successful or not. default=false.
+ *     result: tracks a shared_ptr result.
+ *     callback: invoked upon cleanups of automatics at end-of-scope.
+ *
+ *
+ * The callback_t is a function void(bool explicit_) where explicit_ indicates
+ * whether or not the callback was initiated by function-call-operator or
+ * by scope-cleanup.
+ *
+ * In most cases explicit_ may be ignored if the callback operations only
+ * involve modifying/clearing result, as result itself (if any) will simply
+ * be deleted by shared_ptr<T>.
+ *
+ * Undefined behaviour results if callback throws exception.
+ *
+ ******************************************************************************
+ */
+template<typename T>
+class result_guard_c {
+  result_guard_c(const result_guard_c &) = delete;
+  result_guard_c(result_guard_c &&) = delete;
+  result_guard_c &operator=(const result_guard_c &) = delete;
+  result_guard_c &operator=(result_guard_c &&) = delete;
+
+public:
+  using result_t   = std::shared_ptr<T>;
+  using callback_t = std::function<void(bool)>;
+
+  result_guard_c(callback_t callback_ = {})
+    : callback(callback_) { }
+
+  ~result_guard_c() {
+    invoke_callback(false);
+  }
+
+  result_t
+  operator ()() {
+    invoke_callback(true);
+    return this->result;
+  }
+
+  result_t
+  operator ()(bool success_) {
+    this->success = success_;
+    invoke_callback(true);
+    return this->result;
+  }
+
+  T*
+  operator ->() {
+    return this->result.get();
+  }
+
+  T*
+  operator *() {
+    return this->result.get();
+  }
+
+  void
+  make_result() {
+    this->result = std::make_shared<T>();
+  }
+
+  template<typename... Args>
+  void
+  make_result(Args&&... args) {
+    this->result = std::make_shared<T>(std::forward<Args>(args)...);
+  }
+
+  bool       success{};
+  result_t   result{};
+  callback_t callback{};
+
+private:
+  void
+  invoke_callback(bool explicit_) {
+    if (!this->callback)
+      return;
+    this->callback(explicit_);
+    this->callback = nullptr;
+  }
+};
+
+}} // namespace mtx::sbrm
+
+#endif // MTX_SBRM_H

--- a/src/input/r_dts.cpp
+++ b/src/input/r_dts.cpp
@@ -28,7 +28,7 @@
 #include "merge/input_x.h"
 #include "output/p_dts.h"
 
-#define READ_SIZE 16384
+#define READ_SIZE 32768
 
 int
 dts_reader_c::probe_file(mm_io_c *in,


### PR DESCRIPTION
DTS:X detection is minimal and only checks for a syncword. There is yet
no released technical spec for a DTS:X header.

This implementation does not scan a range of bytes for the syncword,
rather it first performs more thorough decoding of XLL header necessary
to reliably find the exact syncword position.

Incidental,
sbrm.h provides Scope-Bound Resource Management (SBRM) utilities.

Incidental,
{ format.h, format.cpp } provide boost::format helpers, useful when
producing debug output of tables based on key-value pairs.
