### PR TITLE
Update de.po

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -5902,7 +5902,7 @@ msgstr "&Sprache der Benutzeroberfläche:"
 #: src/info/mkvinfo.cpp:746
 #, boost-format
 msgid "Interlaced: %1%"
-msgstr "Verschränkt: %1%"
+msgstr "Zeilensprungverfahren: %1%"
 
 #: src/extract/xtr_textsubs.cpp:133
 #, boost-format


### PR DESCRIPTION
I have never ever heard the term "verschränkt" as a translation of interlaced. And I'm probably not alone: Searching on forum.gleitz.info for "verschränkt" found three topics (two of which actually use it in the sense of interlaced (but I'd say that neither of these topics uses "verschränkt" as German for "interlaced")), but 500 for interlaced (that's probably the maximum number of search results one can get, so there are probably more than 500 topics).