### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ MKVToolNix 9.7.0
 
 # 1. Introduction
 
-With these tools one can get information about (mkvinfo) Matroska
-files, extract tracks/data from (mkvextract) Matroska files and create
-(mkvmerge) Matroska files from other media files. Matroska is a new
+With these tools one can get information about (via mkvinfo) Matroska
+files, extract tracks/data from (via mkvextract) Matroska files and create
+(via mkvmerge) Matroska files from other media files. Matroska is a new
 multimedia file format aiming to become THE new container format for
 the future. You can find more information about it and its underlying
 technology, the Extensible Binary Meta Language (EBML), at
@@ -53,16 +53,16 @@ Moritz Bunkus <moritz@bunkus.org>
 
 # 2. Installation
 
-If you want to compile the tools yourself then you must first decide
+If you want to compile the tools yourself, then you must first decide
 if you want to use a 'proper' release version or the current
 development version. As both Matroska and MKVToolNix are under heavy
-development there might be features available in the git repository
+development, there might be features available in the git repository
 that are not available in the releases. On the other hand the git
 repository version might not even compile.
 
 ## 2.1. Requirements
 
-In order to compile MKVToolNix you need a couple of libraries. Most of
+In order to compile MKVToolNix, you need a couple of libraries. Most of
 them should be available pre-compiled for your distribution. The
 programs and libraries you absolutely need are:
 
@@ -92,7 +92,7 @@ programs and libraries you absolutely need are:
 You also need the `rake` or `drake` build program or at least the
 programming language Ruby and the "rubygems" package. MKVToolNix comes
 bundled with its own copy of "drake" in case you cannot install it
-yourself. If you want to install it yourself I suggest you use the
+yourself. If you want to install it yourself, I suggest you use the
 "drake" version because it will be able to use all available CPU cores
 for parallel builds.
 
@@ -167,7 +167,7 @@ the GNU "autoconf" utility for this step.
 
 ### 2.4.2. Configuration and compilation
 
-If you have run `make install` for both libraries then `configure`
+If you have run `make install` for both libraries, then `configure`
 should automatically find the libraries' position. Otherwise you need
 to tell `configure` where the libEBML and libMatroska include and
 library files are:
@@ -177,10 +177,10 @@ library files are:
       --with-extra-libs=/where/i/put/libebml/make/linux\;/where/i/put/libmatroska/make/linux
 
 Now run `rake` and, as "root", `rake install`. If you don't have
-"rake" installed yourself then use the version bundled with
+"rake" installed yourself, then use the version bundled with
 MKVToolNix: `./drake` and `./drake install`.
 
-If you want to use all available CPU cores for building then you have
+If you want to use all available CPU cores for building, then you have
 to use `drake` instead of `rake`. `drake` knows the parameter `-j`
 much like `make` does. You can also set the environment variable
 DRAKETHREADS to a number and the build process will automatically use
@@ -207,7 +207,7 @@ additional options for `configure`:
 ## 2.6. Unit tests
 
 Building and running unit tests is completely optional. If you want to
-do this then you have to follow these steps:
+do this, then you have to follow these steps:
 
 1. Download the "googletest" framework from
    http://code.google.com/p/googletest/ (at the time of writing the
@@ -239,11 +239,11 @@ of the original data, then by all means submit a bug report.
 
 I use [GitHub's issue system](https://github.com/mbunkus/mkvtoolnix/issues)
 as my bug database. You can submit your bug reports there. Please be as
-verbose as possible — e.g. include the command line, if you use Windows
+verbose as possible — e.g. include the command line if you use Windows
 or Linux etc.pp.
 
-If at all possible please include sample files as well so that I can
-reproduce the issue. If they are larger than 1 MB then please upload
+If at all possible, please include sample files as well so that I can
+reproduce the issue. If they are larger than 1 MB, then please upload
 them somewhere and post a link in the issue. You can also upload them
 to my FTP server. Details on how to connect can be found in the
 [MKVToolNix FAQ](https://github.com/mbunkus/mkvtoolnix/wiki/FTP-server).

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Moritz Bunkus <moritz@bunkus.org>
 
 # 2. Installation
 
-If you want to compile the tools yourself, then you must first decide
+If you want to compile the tools yourself, you must first decide
 if you want to use a 'proper' release version or the current
 development version. As both Matroska and MKVToolNix are under heavy
 development, there might be features available in the git repository
@@ -177,10 +177,10 @@ library files are:
       --with-extra-libs=/where/i/put/libebml/make/linux\;/where/i/put/libmatroska/make/linux
 
 Now run `rake` and, as "root", `rake install`. If you don't have
-"rake" installed yourself, then use the version bundled with
+"rake" installed yourself, use the version bundled with
 MKVToolNix: `./drake` and `./drake install`.
 
-If you want to use all available CPU cores for building, then you have
+If you want to use all available CPU cores for building, you have
 to use `drake` instead of `rake`. `drake` knows the parameter `-j`
 much like `make` does. You can also set the environment variable
 DRAKETHREADS to a number and the build process will automatically use
@@ -207,7 +207,7 @@ additional options for `configure`:
 ## 2.6. Unit tests
 
 Building and running unit tests is completely optional. If you want to
-do this, then you have to follow these steps:
+do this, you have to follow these steps:
 
 1. Download the "googletest" framework from
    http://code.google.com/p/googletest/ (at the time of writing the
@@ -239,11 +239,11 @@ of the original data, then by all means submit a bug report.
 
 I use [GitHub's issue system](https://github.com/mbunkus/mkvtoolnix/issues)
 as my bug database. You can submit your bug reports there. Please be as
-verbose as possible — e.g. include the command line if you use Windows
+verbose as possible — e.g. include the command line, if you use Windows
 or Linux etc.pp.
 
 If at all possible, please include sample files as well so that I can
-reproduce the issue. If they are larger than 1 MB, then please upload
+reproduce the issue. If they are larger than 1 MB, please upload
 them somewhere and post a link in the issue. You can also upload them
 to my FTP server. Details on how to connect can be found in the
 [MKVToolNix FAQ](https://github.com/mbunkus/mkvtoolnix/wiki/FTP-server).


### PR DESCRIPTION
In order to make the text more beautiful and easier to read/understand for readers, I have added the following changes:

1. Added the word **via** before the product names in brackets → (**via** mkvinfo), (**via** mkvextract), (**via** mkvmerge). The word **via** clearly indicates that these tools are meant to be used for something, and they are not lonely.

2. Added many missing commas, inter alia:

a) before the word **then**. In English we (almost) always add a comma before **then** if it is located in the middle of a sentence. The word **then** is often seen in English conditional sentences, but in 99% cases it's optional, so we can use a subject directly (see also: http://images.slideplayer.com/28/9327486/slides/slide_3.jpg)

For more information about **then** and English conditional sentences, you can visit the following websites: 

• https://en.wikipedia.org/wiki/English_conditional_sentences

• https://en.wikipedia.org/wiki/Conditional_sentence 

b) before a subject (e.g. **I**, **you**) if it is located in the middle of a sentence. For example:  **If you want to install it yourself, I suggest you use..........** In such cases we always add a comma in order to emphasize the difference between two sentences (two subjects); in the first one: **you** and in the second one: **I**. Thanks to the comma we can easily distinguish them when reading the text.

c) before an (ad)verb if a sentence starts with **If**. For example: **If at all possible, please include.......**. In this case I have added the comma in order to separate an adjective (**possible**) and an (ad)verb (**please**). And also before the adverb **there** which is located in the middle of a sentence and before a noun (**development**). For example: **As both Matroska and MKVToolNix are under heavy development, there might be features......**. 

3. Removed one unnecessary comma which was located before **if** (when the **if-clause** is at the end) → **e.g. include the command line, if you use Windows or Linux etc.pp.** In English we don't generally add a comma if the word **if** is located in the middle of a sentence. See here for examples:
http://images.slideplayer.com/11/3193271/slides/slide_4.jpg and also above for the English Wikipedia (conditional sentences).