### PR TITLE
APE Tags: fix size parsing and add support for APEv1 tags

### DIFF
--- a/src/common/ape.cpp
+++ b/src/common/ape.cpp
@@ -19,15 +19,15 @@
 #include "common/mm_io.h"
 
 int
-apev2_tag_present_at_end(mm_io_c &io) {
-  unsigned char buffer[16];
+ape_tag_present_at_end(mm_io_c &io) {
+  unsigned char buffer[24];
 
   io.save_pos();
   at_scope_exit_c restore([&io]() { io.restore_pos(); });
 
   if (io.setFilePointer2(-32, seek_end) == false)
     return 0;
-  if (io.read(buffer, 16) != 16)
+  if (io.read(buffer, 24) != 24)
     return 0;
 
   if (   strncmp((char *)buffer, "APETAGEX", 8)
@@ -36,12 +36,9 @@ apev2_tag_present_at_end(mm_io_c &io) {
   }
 
   auto tag_size = get_uint32_le(buffer + 12);
-  tag_size     += 32;          // tag footer
+  auto flags    = get_uint32_le(buffer + 20);
+  if (flags & (1U << 31))
+      tag_size += 32;          // tag header
 
   return tag_size;
-}
-
-int
-ape_tag_present_at_end(mm_io_c &io) {
-  return apev2_tag_present_at_end(io);
 }

--- a/src/common/ape.h
+++ b/src/common/ape.h
@@ -17,7 +17,6 @@
 
 #include "common/common_pch.h"
 
-int apev2_tag_present_at_end(mm_io_c &io);
 int ape_tag_present_at_end(mm_io_c &io);
 
 #endif // MTX_COMMON_APE_COMMON_H


### PR DESCRIPTION
What we're reading is the footer, mandatory in all APEv1 files and in all
APEv2 files where the tags are at the end.
The header however is nonexistant in APEv1 and optional in APEv2 if the
tags are at the end of the file, so check its presence by looking at the
APE Tag flags instead of assuming it's always there.

Remove a now unnecessary function while at it as no APEv1 specific function
will be needed.

Signed-off-by: James Almer <jamrial@gmail.com>