### PR TITLE
Add RFC8081 Media Types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,8 @@
   with `segment_duration == 0` when there's more than one edit list entry. In
   that case mkvmerge was reading the whole content more than once. Fixes
   #2152.
+* mkvmerge: Media Types: Added RFC8081 Media Types. This means mkvmerge can
+  detect and use the new font/ttf, font/otf, font/woff, and font/woff2 mime types
 
 
 # Version 18.0.0 "Apricity" 2017-11-18

--- a/src/common/extern_data.cpp
+++ b/src/common/extern_data.cpp
@@ -8,6 +8,7 @@
 
    Written by Moritz Bunkus <moritz@bunkus.org>.
    Changes by Robert Millan <rmh@aybabtu.com>.
+   Changes by Daniel Løvbrøtte Olsen <daniel@dodsorf.as>
 */
 
 #include "common/common_pch.h"
@@ -2187,6 +2188,12 @@ std::vector<mime_type_t> const mime_types = {
   { "audio/x-wav",                                            { "wav" }                                                },
   { "chemical/x-pdb",                                         { "pdb" }                                                },
   { "chemical/x-xyz",                                         { "xyz" }                                                },
+  { "font/sfnt",                                              {}                                                       },
+  { "font/ttf",                                               {}                                                       },
+  { "font/otf" ,                                              {}                                                       },
+  { "font/collection",                                        {}                                                       },
+  { "font/woff",                                              { "woff" }                                               },
+  { "font/woff2",                                             { "woff2" }                                              },
   { "image/bmp",                                              { "bmp" }                                                },
   { "image/cgm",                                              {}                                                       },
   { "image/cgmComputerGraphicsMetafile",                      {}                                                       },


### PR DESCRIPTION
[RFC8081](https://tools.ietf.org/html/rfc8081) adds a top level Media Type for fonts, it also adds ttf, otf,woff, and woff2 subtypes along with the more general sfnt and collection

This pull request adds the rfc8081 media types, and removes the old unoffical x-truetype-font mime type

I also changed the truetype mime detection special case to font/ttf instead of x-truetype-font, when seeing both the old and the "new old" mime types. I'm honestly not sure what that function is doing or why truetype fonts in particular have this special case. So feel free to suggest edits to that commit