### PR TITLE
Update NEWS.md

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,8 +11,8 @@
   with `segment_duration == 0` when there's more than one edit list entry. In
   that case mkvmerge was reading the whole content more than once. Fixes
   #2152.
-* mkvmerge: Media Types: Added RFC8081 Media Types. This means mkvmerge can
-  detect and use the new font/ttf, font/otf, font/woff, and font/woff2 mime types
+* mkvmerge: Media Types: added RFC8081 Media Types. This means mkvmerge can
+  detect and use the new font/ttf, font/otf, font/woff, and font/woff2 mime types.
 
 
 # Version 18.0.0 "Apricity" 2017-11-18

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@
   that case mkvmerge was reading the whole content more than once. Fixes
   #2152.
 * mkvmerge: Media Types: added RFC8081 Media Types. This means mkvmerge can
-  detect and use the new font/ttf, font/otf, font/woff, and font/woff2 mime types.
+  detect and use the new font/ttf, font/otf, font/woff, and font/woff2 MIME types.
 
 
 # Version 18.0.0 "Apricity" 2017-11-18


### PR DESCRIPTION
In English, after the colon ( `:` ), we generally don't capitalize the first letter (in this case "A"), therefore I have changed that: 

**A** (wrong) → **a** (correct). 

And the most important: I have added the missing dot ( `.` ) at the end of the sentence.

See also: http://www.grammarbook.com/punctuation/colons.asp

**EDIT**: I have also fixed the word "MIME": 

mime (wrong) → MIME (correct).